### PR TITLE
Make arabic_rtlize compatible with Python 3

### DIFF
--- a/arabic_rtlize/forms.py
+++ b/arabic_rtlize/forms.py
@@ -2,6 +2,8 @@
     Author: Hasen il Judy
     License: GPL v2 or LGPL v2.1
 """
+    
+from six import unichr
 
 class HarfForms:
     """


### PR DESCRIPTION
This patch uses unichr (which no longer exists in Python 3) from six